### PR TITLE
Add rabbitmq-server as package dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,8 @@ parts:
     plugin: dump
     source: https://github.com/nicolasbock/rabbitmq-support-tools.git
     source-commit: main
+    stage-packages:
+      - rabbitmq-server
     organize:
       rebalance-queue-masters: bin/
       rabbitmq-support: bin/


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>