### PR TITLE
Remove snapstore for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # rabbitmq-support-tools-snap
 
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/rabbitmq-support-tools)
 [![CI](https://github.com/nicolasbock/rabbitmq-support-tools-snap/actions/workflows/CI.yaml/badge.svg)](https://github.com/nicolasbock/rabbitmq-support-tools-snap/actions/workflows/CI.yaml)
 [![CI](https://github.com/nicolasbock/rabbitmq-support-tools-snap/actions/workflows/package.yaml/badge.svg)](https://github.com/nicolasbock/rabbitmq-support-tools-snap/actions/workflows/package.yaml)
 


### PR DESCRIPTION
The snap is not working.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>